### PR TITLE
ValidatingObserver@performValidation should respond on false only

### DIFF
--- a/src/Watson/Validating/ValidatingObserver.php
+++ b/src/Watson/Validating/ValidatingObserver.php
@@ -62,7 +62,10 @@ class ValidatingObserver
         // If the model has validating enabled, perform it.
         if ($model->getValidating() && $model->getRuleset($event))
         {
-            return $model->isValid($event);
+            if( $model->isValid($event) === false )
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
I found that when a model was valid that any other events listening after validation will not get fired because `performValidation()` returns boolean always. The default listener halts if a non null response is given so any additional listeners will not get fired. So a simple fix is to change in `ValidatingObserver@performValidation` to:

``` php
    /**
     * Perform validation with the specified ruleset.
     *
     * @param  object  $model
     * @param  string  $event
     * @return bool | void
     */
    protected function performValidation($model, $event)
    {
        // If the model has validating enabled, perform it.
        if ($model->getValidating() && $model->getRuleset($event))
        {
            if( $model->isValid($event) === false )
            {
                return false;
            }
        }
    }
```

Listening specifically to `isValid()` won't change and so this should't effect any of the tests but it will effect the listeners. On a `false` comparison it will return `false` (technically any response would suffice) and the `Dispatcher@fire` method will halt. So any pre-validation event listeners get fired and post-validation events get fired. I have a trait that listens to `eloquent.saving` and needs to be fired after validation listener passes `isValid()` but should not get fired if `isValid()` fails: this code fixes that behavior. Observers operate as simple middleware most of the time returning void and only halt if the response is given so returning `true` really doesn't fit here.
