### PR TITLE
Use getRules()

### DIFF
--- a/src/Watson/Validating/ValidatingTrait.php
+++ b/src/Watson/Validating/ValidatingTrait.php
@@ -149,9 +149,11 @@ trait ValidatingTrait
      */
     public function getRuleset($ruleset)
     {
-        if (array_key_exists($ruleset, $this->rules))
+        $rules = $this->getRules();
+
+        if (array_key_exists($ruleset, $rules))
         {
-            return $this->rules[$ruleset];
+            return $rules[$ruleset];
         }
     }
 


### PR DESCRIPTION
If not, if `use Watson\Validating\ValidatingTrait;` is declared and `protected $rules = []` is not, an error will pop
