### PR TITLE
Return saving ruleset when mergeWithSaving is true

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -169,6 +169,12 @@ trait ValidatingTrait {
 
             return $rulesets[$ruleset];
         }
+        elseif ($mergeWithSaving && isset($rulesets['saving']))
+        {
+            return $rulesets['saving'];
+        }
+       
+        return [];
     }
 
     /**


### PR DESCRIPTION
For the CMS I'm making, I want to get the ruleset for updating/creating, the same as used for the validation (so Former can automatically add html5 rules). But the updating/creating rules aren't always set, sometimes it's just the saving ruleset. When I set the $mergeWithSaving to true, I except this also to be the case when the requested set is empty.
And when they are all empty, I would expect an empty array, to prevent errors with empty foreaches/merges etc.
