### PR TITLE
Remove check for default rules

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -136,7 +136,7 @@ trait ValidatingTrait {
      * an empty array
      *
      * @param  string $ruleset
-     * @return array
+     * @return array|void
      */
     public function getDefaultRules($ruleset = null)
     {


### PR DESCRIPTION
if $this->getDefaultRules() return an empty array, that evaluates as 'false', so an empty array is never returned.
