### PR TITLE
Set $mergeWithSaving in getRuleset() to true by default

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -139,7 +139,7 @@ trait ValidatingTrait {
      */
     public function getDefaultRules()
     {
-        $rules = $this->getRuleset('saving') ?: $this->getRules();
+        $rules = $this->getRuleset('saving', false) ?: $this->getRules();
 
         return $rules ?: [];
     }
@@ -183,7 +183,7 @@ trait ValidatingTrait {
      * @param  bool   $mergeWithSaving
      * @return array
      */
-    public function getRuleset($ruleset, $mergeWithSaving = false)
+    public function getRuleset($ruleset, $mergeWithSaving = true)
     {
         $rulesets = $this->getRulesets();
 
@@ -235,7 +235,7 @@ trait ValidatingTrait {
 
         foreach ($keys as $key)
         {
-            $rulesets[] = $this->getRuleset($key);
+            $rulesets[] = $this->getRuleset($key, false);
         }
 
         return array_filter(call_user_func_array('array_merge', $rulesets));

--- a/tests/ValidatingTraitTest.php
+++ b/tests/ValidatingTraitTest.php
@@ -127,9 +127,15 @@ class ValidatingTraitTest extends \PHPUnit_Framework_TestCase {
     {
         $this->trait->setRuleset(['abc' => 123], 'foo');
 
-        $this->assertEquals(['abc' => 123], $this->trait->getRuleset('foo'));
+        $this->assertEquals(['abc' => 123, 'foo' => 'bar'], $this->trait->getRuleset('foo'));
     }
 
+    public function testSetRulesetWithNameWithoutDefaultMerged()
+    {
+        $this->trait->setRuleset(['abc' => 123], 'foo');
+
+        $this->assertEquals(['abc' => 123], $this->trait->getRuleset('foo', false));
+    }
 
     public function testMergeRulesets()
     {
@@ -137,7 +143,6 @@ class ValidatingTraitTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(['baz' => 'bat', 'foo' => 'baz'], $result);
     }
-
 
     public function testGetMessages()
     {


### PR DESCRIPTION
Bringing this in line with isValid, where $mergeWithSaving is also `true` by default.
Note: this could be a breaking change, but should be fine as long as it is done during the 0.9.x to 0.10.x bump
