### PR TITLE
Change Confirmation to not use array_flip()

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -439,12 +439,17 @@ trait ValidatingTrait {
      */
     public function getConfirmationAttributes()
     {
-        $input = Input::all();
-
-        return array_flip(array_filter(array_flip($input), function($key)
+        $attributes = array();
+        
+        foreach (Input::all() as $key => $value)
         {
-            return Str::endsWith($key, '_confirmation');
-        }));
+            if (ends_with($key, '_confirmation'))
+            {
+                $attributes[$key] = $value;
+            }
+        }
+        
+        return $attributes;
     }
 
     /**


### PR DESCRIPTION
I get the following error in ValidatingTrait.php, getConfirmationAttributes():

> array_flip(): Can only flip STRING and INTEGER values!

This happens when I use a file input field for example.
