### PR TITLE
Prevent errors in merge rulesets()

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -198,7 +198,7 @@ trait ValidatingTrait {
 
         foreach ($keys as $key)
         {
-            $rulesets[] = $this->getRuleset($key);
+            $rulesets[] = $this->getRuleset($key) ?: [];
         }
 
         return array_filter(call_user_func_array('array_merge', $rulesets));


### PR DESCRIPTION
If the 'saving' $key is not set on the Model.

It was throwing a "array_merge(): Argument #1 is not an array" error on #204
