### PR TITLE
Validation should setErrors even we validation passes. Fixes #85.

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -534,11 +534,9 @@ trait ValidatingTrait {
     {
         $validation = $this->makeValidator($rules);
 
-        if ($validation->passes()) return true;
-
         $this->setErrors($validation->messages());
 
-        return false;
+        return $validation->passes();
     }
 
     /**


### PR DESCRIPTION
Third time might be the charm. Same pull request as #85 but cherry picked from develop and targeted at develop.
