### PR TITLE
Fixes a NaA bug by casting rulesets to an array.

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -314,7 +314,7 @@ trait ValidatingTrait {
 
         foreach ($keys as $key)
         {
-            $rulesets[] = $this->getRuleset($key, false);
+            $rulesets[] = (array) $this->getRuleset($key, false);
         }
 
         return array_filter(call_user_func_array('array_merge', $rulesets));


### PR DESCRIPTION
This fixes the `array_merge(): Argument #1 is not an array` error that arises when your ruleset key is called but doesn't exist or returns a null value instead of an empty array.
