### PR TITLE
Update ValidatingTrait.php

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -604,7 +604,7 @@ trait ValidatingTrait {
 
             foreach ($ruleset as &$rule)
             {
-                if (starts_with($rule, 'unique'))
+                if (starts_with($rule, 'unique:'))
                 {
                     $rule = $this->prepareUniqueRule($rule, $field);
                 }


### PR DESCRIPTION
Fixed unique validation rule detection to only detect the `unique:` rule and not other similar named rules like `unique_with:`
