### PR TITLE
Add Laravel 5.1 support and fix test errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/contracts": "~5.0",
-        "illuminate/database": "~5.0",
-        "illuminate/events": "~5.0",
-        "illuminate/support": "~5.0",
-        "illuminate/validation": "~5.0"
+        "illuminate/contracts": "5.0.*|5.1.*",
+        "illuminate/database": "5.0.*|5.1.*",
+        "illuminate/events": "5.0.*|5.1.*",
+        "illuminate/support": "5.0.*|5.1.*",
+        "illuminate/validation": "5.0.*|5.1.*"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "4.2.*"
+        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/ValidatingObserverTest.php
+++ b/tests/ValidatingObserverTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use \Illuminate\Support\Facades\Event;
-use \Mockery;
 use \Watson\Validating\ValidatingObserver;
 
 class ValidatingObserverTest extends \PHPUnit_Framework_TestCase {

--- a/tests/ValidationExceptionTest.php
+++ b/tests/ValidationExceptionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use \Mockery;
 use \Watson\Validating\ValidationException;
 
 class ValidationExceptionTest extends \PHPUnit_Framework_TestCase {


### PR DESCRIPTION
Also removed `~` from version number since Laravel future `5.*` versions may break stuff.