### PR TITLE
Fix bug with automatic adding of table name

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -420,7 +420,7 @@ trait ValidatingTrait
         $parameters = explode(',', substr($rule, 7));
 
         // If the table name isn't set, get it.
-        if (! isset($parameters[0])) {
+        if (! isset($parameters[0]) || strlen($parameters[0]) === 0) {
             $parameters[0] = $this->getModel()->getTable();
         }
 


### PR DESCRIPTION
The result of `explode(',', substr($rule, 7))` on line 420 is *always* an array, so `isset($parameters[0])` always returns true. This change makes it so the check on line 423 looks for an empty string as well, which is what happens when the standalone 'unique' rule is declared.