### PR TITLE
Cast attributes before validating

### DIFF
--- a/src/ValidatingInterface.php
+++ b/src/ValidatingInterface.php
@@ -69,6 +69,13 @@ interface ValidatingInterface
     public function getModel();
 
     /**
+     * Get the casted model attributes.
+     *
+     * @return array
+     */
+    public function getModelAttributes();
+
+    /**
      * Get the global validation rules.
      *
      * @return array

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -122,6 +122,24 @@ trait ValidatingTrait
     }
 
     /**
+     * Get the casted model attributes.
+     *
+     * @return array
+     */
+    public function getModelAttributes()
+    {
+        $attributes = $this->getAttributes();
+
+        foreach ($attributes as $key => $value) {
+            if ($this->hasCast($key)) {
+                $attributes[$key] = $this->castAttribute($key, $value);
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
      * Get the custom validation messages being used by the model.
      *
      * @return array
@@ -316,8 +334,8 @@ trait ValidatingTrait
      */
     protected function makeValidator($rules = [])
     {
-        // Get the model attributes.
-        $attributes = $this->getModel()->getAttributes();
+        // Get the casted model attributes.
+        $attributes = $this->getModelAttributes();
 
         if ($this->getInjectUniqueIdentifier()) {
             $rules = $this->injectUniqueIdentifierToRules($rules);

--- a/tests/ValidatingTraitTest.php
+++ b/tests/ValidatingTraitTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Database\Eloquent\Model;
 
 class ValidatingTraitTest extends PHPUnit_Framework_TestCase
 {
@@ -82,7 +83,7 @@ class ValidatingTraitTest extends PHPUnit_Framework_TestCase
 
     public function testGetRules()
     {
-        $this->assertEquals(['foo' => 'bar'], $this->trait->getRules());
+        $this->assertEquals(['foo' => 'bar', 'def' => 'array'], $this->trait->getRules());
     }
 
     public function testRules()
@@ -99,6 +100,12 @@ class ValidatingTraitTest extends PHPUnit_Framework_TestCase
         $this->trait->setRules(['bar' => 'foo']);
 
         $this->assertEquals(['bar' => 'foo'], $this->trait->getRules());
+    }
+
+
+    public function testAttributesAreCasted()
+    {
+        $this->assertEquals(['abc' => '123', 'def' => ['456']], $this->trait->getModelAttributes());
     }
 
 
@@ -391,7 +398,7 @@ class ValidatingTraitTest extends PHPUnit_Framework_TestCase
     }
 }
 
-class DatabaseValidatingTraitStub implements \Watson\Validating\ValidatingInterface
+class DatabaseValidatingTraitStub extends Model implements \Watson\Validating\ValidatingInterface
 {
     use \Watson\Validating\ValidatingTrait;
 
@@ -400,12 +407,18 @@ class DatabaseValidatingTraitStub implements \Watson\Validating\ValidatingInterf
     protected $addUniqueIdentifierToRules = true;
 
     protected $rules = [
-        'foo' => 'bar'
+        'foo' => 'bar',
+        'def' => 'array'
     ];
 
     protected $validationMessages = [
         'bar' => 'baz'
     ];
+
+    protected $casts = [
+        'def' => 'array'
+    ];
+
 
     public function getTable()
     {
@@ -424,7 +437,7 @@ class DatabaseValidatingTraitStub implements \Watson\Validating\ValidatingInterf
 
     public function getAttributes()
     {
-        return ['abc' => '123'];
+        return ['abc' => '123', 'def' => $this->asJson(['456'])];
     }
 }
 


### PR DESCRIPTION
Eloquent allows to cast attributes upon getting or setting them.
This allows developers to simply pass serializable entities such as arrays and objects to Eloquent without ever needing to worry about the database format.

Since this package hooks into storing values in the database, it seems obvious to me that validation is performed on the value a developer expects to get and set.

An example to justify this:

```php
class Model {
    use ValidatingTrait;

    public $casts = [ 'myAttribute' => 'array' ];
    public $rules = [ 'myAttribute' => 'array' ];
}
```
This attribute can be set using an array because of `$casts`:
```php
$model->myAttribute = array('value_1', 'value_2');
```
However validation performed by this package will happen on the casted database value, namely the `json_encode` version of the array, which in essence is just a plain string:
```json
'["value_1","value_2"]'
```

So although the developer notifies Eloquent that the attribute is an array, he needs to set a `string` rule for the validator to effectively pass. This seems contradictory to me, hence this PR that takes into account casting.