### PR TITLE
Fix updateRulesUniques

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -397,7 +397,13 @@ trait ValidatingTrait
     {
         $rules = $this->getRules();
 
-        $this->setRules($this->injectUniqueIdentifierToRules($rules));
+        $updatedRules = $this->injectUniqueIdentifierToRules($rules);
+
+        foreach ($updatedRules as &$rule) {
+            $rule = implode('|', $rule);
+        }
+
+        $this->setRules($updatedRules);
     }
 
     /**


### PR DESCRIPTION
This method didn't implode the rules and hereby assigns a multidimensional array to the `$rules` property, which is faulty when compared to how the property is set through other ways.