### PR TITLE
Injection of unique identifier for all unique-like rules

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -431,7 +431,7 @@ trait ValidatingTrait
             $ruleset = is_string($ruleset) ? explode('|', $ruleset) : $ruleset;
 
             foreach ($ruleset as &$rule) {
-                if (starts_with($rule, 'unique:') || $rule === 'unique') {
+                if (starts_with($rule, 'unique')) {
                     $rule = $this->prepareUniqueRule($rule, $field);
                 }
             }


### PR DESCRIPTION
I'd expect that *any* unique-like rule would need some identifier injection, so why not make it more generic in code?

This allows for ease of use in conjunction with for example the [unique_with](https://github.com/felixkiss/uniquewith-validator) validator.