### PR TITLE
Make model identifier injection more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ You can adjust this functionality by setting the `$injectUniqueIdentifier` prope
 protected $injectUniqueIdentifier = true;
 ```
 
+For automatically injecting model identifiers for third-party validators with unique-like behavior, set the `uniqueRulesForInjection` property on a model.
+
+```php
+/**
+ * Additional rules for injection of the model identifier.
+ *
+ * @var array
+ */
+protected $uniqueRulesForInjection = ['unique_with'];
+```
+
 ### Events
 Various events are fired by the trait during the validation process which you can hook into to impact the validation process.
 

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -400,9 +400,32 @@ trait ValidatingTrait
     }
 
     /**
+     * Returns the rules for injection of the model identifier.
+     *
+     * @return array
+     */
+    public function getUniqueRulesForInjection()
+    {
+        return isset($this->uniqueRulesForInjection) ? array_unique(array_merge($this->uniqueRulesForInjection, ['unique'])) : ['unique'];
+    }
+
+    /**
+     * Set the rules for injection of the model identifier.
+     *
+     * @param  array $value
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public function setUniqueRulesForInjection(array $value)
+    {
+        $this->uniqueRulesForInjection = $value;
+    }
+
+    /**
      * Update the unique rules of the global rules to
      * include the model identifier.
      *
+     * @param string|array $uniqueRule
      * @return void
      */
     public function updateRulesUniques()
@@ -431,8 +454,10 @@ trait ValidatingTrait
             $ruleset = is_string($ruleset) ? explode('|', $ruleset) : $ruleset;
 
             foreach ($ruleset as &$rule) {
-                if (starts_with($rule, 'unique:') || $rule === 'unique') {
-                    $rule = $this->prepareUniqueRule($rule, $field);
+                foreach ($this->getUniqueRulesForInjection() as $forRule) {
+                    if (starts_with($rule, $forRule . ':') || $rule === $forRule) {
+                        $rule = $this->prepareUniqueRule($rule, $field);
+                    }
                 }
             }
         }


### PR DESCRIPTION
As a follow-up on https://github.com/dwightwatson/validating/pull/153.

This PR allows developers to specify the rules for model identifier injection in `$uniqueRulesForInjection`.
This primarily prevents code duplication that would occur as you suggested in https://github.com/dwightwatson/validating/pull/153.