### PR TITLE
Make validationAttributeNames protected

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -32,6 +32,13 @@ trait ValidatingTrait
      * @return \Illuminate\Validation\Factory
      */
     protected $validator;
+    
+    /**
+     * The custom validation attribute names.
+     * 
+     * @var array;
+     */
+    protected $validationAttributeNames;
 
     /**
      * Boot the trait. Adds an observer class for validating.


### PR DESCRIPTION
setValidationAttributeNames sets the given array as a public property, that is exposed as model attribute to Eloquent. Saving the model makes Eloquent try to save the model with the "validationAttributeNames" attribute, which will fail. Instead, make it a protected property.