### PR TITLE
Validate in creating/updating instead of saving event

### DIFF
--- a/src/ValidatingObserver.php
+++ b/src/ValidatingObserver.php
@@ -9,13 +9,23 @@ use Watson\Validating\ValidationException;
 class ValidatingObserver
 {
     /**
-     * Register the validation event for saving the model. Saving validation
-     * should only occur if creating and updating validation does not.
+     * Register the validation event for creating the model.
      *
      * @param  \Illuminate\Database\Eloquent\Model $model
      * @return boolean
      */
-    public function saving(Model $model)
+    public function creating(Model $model)
+    {
+        return $this->performValidation($model, 'saving');
+    }
+    
+    /**
+     * Register the validation event for updating the model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @return boolean
+     */
+    public function updating(Model $model)
     {
         return $this->performValidation($model, 'saving');
     }

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -47,7 +47,7 @@ trait ValidatingTrait
      */
     public static function bootValidatingTrait()
     {
-        static::observe(new ValidatingObserver);
+        static::observe(new ValidatingObserver, -100);
     }
 
     /**

--- a/tests/ValidatingObserverTest.php
+++ b/tests/ValidatingObserverTest.php
@@ -30,7 +30,7 @@ class ValidatingObserverTest extends PHPUnit_Framework_TestCase
         Event::shouldReceive('fire')
             ->once();
 
-        $response = $this->observer->saving($this->model);
+        $response = $this->observer->creating($this->model);
         $this->assertNotFalse($response);
     }
 
@@ -40,7 +40,7 @@ class ValidatingObserverTest extends PHPUnit_Framework_TestCase
 
         Event::shouldReceive('until')->once()->andReturn(false);
 
-        $result = $this->observer->saving($this->model);
+        $result = $this->observer->updating($this->model);
 
         $this->assertNull($result);
     }
@@ -57,7 +57,7 @@ class ValidatingObserverTest extends PHPUnit_Framework_TestCase
             ->once()
             ->andReturn(false);
 
-        $response = $this->observer->saving($this->model);
+        $response = $this->observer->creating($this->model);
         $this->assertFalse($response);
     }
 
@@ -76,11 +76,11 @@ class ValidatingObserverTest extends PHPUnit_Framework_TestCase
         $this->model->shouldReceive('throwValidationException')
             ->once();
 
-        $response = $this->observer->saving($this->model);
+        $response = $this->observer->updating($this->model);
         $this->assertFalse($response);
     }
 
-    public function testSavingPerformsValidation()
+    public function testCreatingPerformsValidation()
     {
         $this->model->shouldReceive('getValidating')->once()->andReturn(true);
 
@@ -94,7 +94,24 @@ class ValidatingObserverTest extends PHPUnit_Framework_TestCase
         Event::shouldReceive('fire')
             ->once();
 
-        $this->observer->saving($this->model);
+        $this->observer->creating($this->model);
+    }
+
+    public function testUpdatingPerformsValidation()
+    {
+        $this->model->shouldReceive('getValidating')->once()->andReturn(true);
+
+        $this->model->shouldReceive('isValid')
+            ->once()
+            ->andReturn(true);
+
+        Event::shouldReceive('until')
+            ->once();
+
+        Event::shouldReceive('fire')
+            ->once();
+
+        $this->observer->updating($this->model);
     }
 
     public function testRestoringPerformsValidation()
@@ -121,6 +138,6 @@ class ValidatingObserverTest extends PHPUnit_Framework_TestCase
         Event::shouldReceive('fire')
             ->once();
 
-        $this->observer->saving($this->model);
+        $this->observer->creating($this->model);
     }
 }


### PR DESCRIPTION
Hi

Laravel's model events are fired in the following order:

1. saving
2. creating / updating
3. created / updated
4. saved

Right now the Validating trait hooks in at the first event (saving). Yet it seems logical to me that this kind of validation happens right before the actual save, so in between 2 and 3. This way developers can easily set or unset attributes in `creating()` or `updating()` while having validation to happen on the final saveable attributes.

A side-by-side example. Let's say I want to set an attribute during creation and pad it during updating to a certain length before having it validated (this is just a pseudo example of course).

Since validation occurs in an early stage, at the moment this is only possible using conditionals inside `saving()`:

```php
protected static function boot()
{
    parent::boot();
    
    static::saving(function($model) {
        if (! $model->exists) {
            $model->attribute = str_random(32);
        } else {
            $model->attribute = str_pad($model->attribute, 32, '?');
        }
    });
}
```

However, when validation would occur in a final stage, this becomes much cleaner and more readable.

```php
protected static function boot()
{
    parent::boot();
    
    static::creating(function($model) {
        $model->attribute = str_random(32);
    });
    
    static::updating(function($model) {
        $model->attribute = str_pad($model->attribute, 32, '?');
    });
}
```

This PR additionally sets a priority for the observer. I've added this because in this example `parent::boot()` would register validation before the other callbacks; we could set an elevated priority on those but I felt that setting a lower priority on the validation is more failsafe for every possible scenario.