### PR TITLE
Return empty array when no custom attributes are present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -165,7 +165,7 @@ trait ValidatingTrait
     /**
      * Get the validating attribute names.
      *
-     * @return mixed
+     * @return array
      */
     public function getValidationAttributeNames()
     {

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -169,7 +169,7 @@ trait ValidatingTrait
      */
     public function getValidationAttributeNames()
     {
-        return isset($this->validationAttributeNames) ? $this->validationAttributeNames : null;
+        return isset($this->validationAttributeNames) ? $this->validationAttributeNames : [];
     }
 
     /**

--- a/tests/ValidatingTraitTest.php
+++ b/tests/ValidatingTraitTest.php
@@ -70,7 +70,7 @@ class ValidatingTraitTest extends PHPUnit_Framework_TestCase
 
     public function testGetValidationAttributeNames()
     {
-        $this->assertNull($this->trait->getValidationAttributeNames());
+        $this->assertEmpty($this->trait->getValidationAttributeNames());
     }
 
     public function testSetValidationAttributeNames()


### PR DESCRIPTION
This makes the attributes getter return an empty array instead of null. The reason is because this fits better in to patterned use, ie. designers can count on always getting an array, maybe full, maybe empty, but always an array. This is the same pattern Laravel uses itself, where the defaults for their own custom attribute-related code is always an empty array and not null.

This also added the PHPStorm / WebStorm ".idea" settings folder to .gitignore to suppress that folder from being copied in to the project.