### PR TITLE
Make setters default to empty array, fix missing attribute exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ class Post extends Eloquent
 
 You can also add the trait to a `BaseModel` if you're using one and it will work on all models that extend from it, otherwise you can just extend `Watson\Validating\ValidatingModel` instead of `Eloquent`.
 
-*Note: you will need to set the `$rules` property on any models that extend from a `BaseModel` that uses the trait, or otherwise set an empty array as the `$rules` for the `BaseModel`. If you do not, you will inevitably end up with `LogicException with message 'Relationship method must return an object of type Illuminate\Database\Eloquent\Relations\Relation'`.*
-
-Now, you have access to some plesant functionality.
+Now, you have access to some pleasant functionality.
 
 ```php
 // Check whether the model is valid or not.

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -179,7 +179,7 @@ trait ValidatingTrait
      * @param  array  $attributeNames
      * @return mixed
      */
-    public function setValidationAttributeNames(array $attributeNames = null)
+    public function setValidationAttributeNames(array $attributeNames = [])
     {
         $this->validationAttributeNames = $attributeNames;
     }
@@ -211,7 +211,7 @@ trait ValidatingTrait
      * @param  array $rules
      * @return void
      */
-    public function setRules(array $rules = null)
+    public function setRules(array $rules = [])
     {
         $this->rules = $rules;
     }


### PR DESCRIPTION
This does two related things:
- The validation property setters default to empty array instead of null
- Introduces a work-around to correct the LogicException that is thrown when a validating property is missing on a parent model.

So, that error is thrown because Laravel has overwritten the "isset()" method on Eloquent/Model. This is done because otherwise it will not properly handle attributes and relationships which are present on the model using magic methods. This method implementation fails to account just good 'ol class properties added to the model in the manner which this package uses them.

Wrapping the call in a try/catch and then discarding a LogicException as equivalent to "isset(...) === false" resolves this issue. It is then not necessary to define $rules or the other validation properties on the model.