### PR TITLE
Create static getters

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -153,6 +153,17 @@ trait ValidatingTrait
     }
 
     /**
+     * Handy method for using the static call Model::validationMessages(). Protected access
+     * only to allow __callStatic to get to it.
+     *
+     * @return array
+     */
+    protected function validationMessages()
+    {
+        return $this->getValidationMessages();
+    }
+
+    /**
      * Get the custom validation messages being used by the model.
      *
      * @return array
@@ -160,6 +171,17 @@ trait ValidatingTrait
     public function getValidationMessages()
     {
         return isset($this->validationMessages) ? $this->validationMessages : [];
+    }
+
+    /**
+     * Handy method for using the static call Model::validationAttributeNames(). Protected access
+     * only to allow __callStatic to get to it.
+     *
+     * @return array
+     */
+    protected function validationAttributeNames()
+    {
+        return $this->getValidationAttributeNames();
     }
 
     /**

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -153,13 +153,14 @@ trait ValidatingTrait
     }
 
     /**
-     * Access getValidationMessages() on-model default statically.
+     * Handy method for using the static call Model::validationMessages(). Protected access
+     * only to allow __callStatic to get to it.
      *
      * @return array
      */
-    public static function validationMessages()
+    protected function validationMessages()
     {
-        return (new static)->getValidationMessages();
+        return $this->getValidationMessages();
     }
 
     /**
@@ -173,13 +174,14 @@ trait ValidatingTrait
     }
 
     /**
-     * Access getValidationAttributeNames() on-model default statically.
+     * Handy method for using the static call Model::validationAttributeNames(). Protected access
+     * only to allow __callStatic to get to it.
      *
      * @return array
      */
-    public static function validationAttributeNames()
+    protected function validationAttributeNames()
     {
-        return (new static)->getValidationAttributeNames();
+        return $this->getValidationAttributeNames();
     }
 
     /**
@@ -214,13 +216,14 @@ trait ValidatingTrait
     }
 
     /**
-     * Access getRules() on-model default statically.
+     * Handy method for using the static call Model::rules(). Protected access
+     * only to allow __callStatic to get to it.
      *
      * @return array
      */
-    public static function rules()
+    protected function rules()
     {
-        return (new static)->getRules();
+        return $this->getRules();
     }
 
     /**

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -153,14 +153,13 @@ trait ValidatingTrait
     }
 
     /**
-     * Handy method for using the static call Model::validationMessages(). Protected access
-     * only to allow __callStatic to get to it.
+     * Access getValidationMessages() on-model default statically.
      *
      * @return array
      */
-    protected function validationMessages()
+    public static function validationMessages()
     {
-        return $this->getValidationMessages();
+        return (new static)->getValidationMessages();
     }
 
     /**
@@ -174,14 +173,13 @@ trait ValidatingTrait
     }
 
     /**
-     * Handy method for using the static call Model::validationAttributeNames(). Protected access
-     * only to allow __callStatic to get to it.
+     * Access getValidationAttributeNames() on-model default statically.
      *
      * @return array
      */
-    protected function validationAttributeNames()
+    public static function validationAttributeNames()
     {
-        return $this->getValidationAttributeNames();
+        return (new static)->getValidationAttributeNames();
     }
 
     /**
@@ -216,14 +214,13 @@ trait ValidatingTrait
     }
 
     /**
-     * Handy method for using the static call Model::rules(). Protected access
-     * only to allow __callStatic to get to it.
+     * Access getRules() on-model default statically.
      *
      * @return array
      */
-    protected function rules()
+    public static function rules()
     {
-        return $this->getRules();
+        return (new static)->getRules();
     }
 
     /**

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -153,14 +153,13 @@ trait ValidatingTrait
     }
 
     /**
-     * Handy method for using the static call Model::validationMessages(). Protected access
-     * only to allow __callStatic to get to it.
+     * Static access to getValidationMessages() global default.
      *
      * @return array
      */
-    protected function validationMessages()
+    protected static function validationMessages()
     {
-        return $this->getValidationMessages();
+        return (new static())->getValidationMessages();
     }
 
     /**
@@ -174,14 +173,13 @@ trait ValidatingTrait
     }
 
     /**
-     * Handy method for using the static call Model::validationAttributeNames(). Protected access
-     * only to allow __callStatic to get to it.
+     * Static access to getValidationAttributeNames() global default.
      *
      * @return array
      */
-    protected function validationAttributeNames()
+    protected static function validationAttributeNames()
     {
-        return $this->getValidationAttributeNames();
+        return (new static())->getValidationAttributeNames();
     }
 
     /**
@@ -216,14 +214,13 @@ trait ValidatingTrait
     }
 
     /**
-     * Handy method for using the static call Model::rules(). Protected access
-     * only to allow __callStatic to get to it.
+     * Static access to getRules() global default.
      *
      * @return array
      */
-    protected function rules()
+    protected static function rules()
     {
-        return $this->getRules();
+        return (new static())->getRules();
     }
 
     /**

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -153,13 +153,14 @@ trait ValidatingTrait
     }
 
     /**
-     * Static access to getValidationMessages() global default.
+     * Handy method for using the static call Model::validationMessages(). Protected access
+     * only to allow __callStatic to get to it.
      *
      * @return array
      */
-    protected static function validationMessages()
+    protected function validationMessages()
     {
-        return (new static())->getValidationMessages();
+        return $this->getValidationMessages();
     }
 
     /**
@@ -173,13 +174,14 @@ trait ValidatingTrait
     }
 
     /**
-     * Static access to getValidationAttributeNames() global default.
+     * Handy method for using the static call Model::validationAttributeNames(). Protected access
+     * only to allow __callStatic to get to it.
      *
      * @return array
      */
-    protected static function validationAttributeNames()
+    protected function validationAttributeNames()
     {
-        return (new static())->getValidationAttributeNames();
+        return $this->getValidationAttributeNames();
     }
 
     /**
@@ -214,13 +216,14 @@ trait ValidatingTrait
     }
 
     /**
-     * Static access to getRules() global default.
+     * Handy method for using the static call Model::rules(). Protected access
+     * only to allow __callStatic to get to it.
      *
      * @return array
      */
-    protected static function rules()
+    protected function rules()
     {
-        return (new static())->getRules();
+        return $this->getRules();
     }
 
     /**

--- a/tests/ValidatingTraitTest.php
+++ b/tests/ValidatingTraitTest.php
@@ -90,7 +90,7 @@ class ValidatingTraitTest extends PHPUnit_Framework_TestCase
     {
         $this->trait->shouldReceive('getRules')->once()->andReturn('foo');
 
-        $result = $this->trait->rules();
+        $result = $this->trait->getRules();
 
         $this->assertEquals('foo', $result);
     }


### PR DESCRIPTION
This adds static call methods for the attribute names and messages.

It also fixes one of the unit tests which was calling the rules() static method instead of the getRules() non-static method on an instanced class object. This is really a semantic change unless the rules() method is changed for other purposes.