### PR TITLE
Validation incorrect work with accessors Issue #177

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -136,20 +136,7 @@ trait ValidatingTrait
      */
     public function getModelAttributes()
     {
-        $attributes = $this->getModel()->getAttributes();
-
-        foreach ($attributes as $key => $value) {
-            // The validator doesn't handle Carbon instances, so instead of casting
-            // them we'll return their raw value instead.
-            if (in_array($key, $this->getDates()) || $this->isDateCastable($key)) {
-                $attributes[$key] = $value;
-                continue;
-            }
-
-            $attributes[$key] = $this->getModel()->getAttributeValue($key);
-        }
-
-        return $attributes;
+        return $this->getModel()->attributesToArray();
     }
 
     /**


### PR DESCRIPTION
Issue #177
The attributesToArray method already returns attributes that are mutated and converts Carbon dates to strings. Plus, it adds appended accessors and applies type casting.