### PR TITLE
Issue #190: Unique rule should maintain NULL as string when the attribute is NULL.

### DIFF
--- a/src/Injectors/UniqueInjector.php
+++ b/src/Injectors/UniqueInjector.php
@@ -44,7 +44,9 @@ trait UniqueInjector
             // Example: unique:users,email,123,id,username,NULL
             foreach ($parameters as $key => $parameter) {
                 if (strtolower((string) $parameter) === 'null') {
-                    $parameters[$key] = $this->getModel()->{$parameters[$key - 1]};
+                    $val = $this->getModel()->{$parameters[$key - 1]};
+                    // Maintain NULL as string in case the model returns a null value
+                    $parameters[$key] = is_null($val) ? 'NULL' : $val;
                 }
             }
         }

--- a/tests/Injectors/UniqueInjectorTest.php
+++ b/tests/Injectors/UniqueInjectorTest.php
@@ -55,6 +55,21 @@ class UniqueInjectorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['user_id' => ['unique:sqlite.users,user_id,1,id,username,test']], $result);
     }
 
+    public function testUpdateRulesUniquesWithUniquesAndAdditionalWhereClauseInfersAttributesMaintainingNULLValue()
+    {
+        $this->trait->exists = true;
+
+        $this->trait->shouldReceive('getTable')->andReturn('users');
+
+        $this->trait->setRules(['user_id' => 'unique:users,user_id,1,id,deleted,null']);
+
+        $this->trait->updateRulesUniques();
+
+        $result = $this->trait->getRules();
+
+        $this->assertEquals(['user_id' => ['unique:sqlite.users,user_id,1,id,deleted,NULL']], $result);
+    }
+
     public function testUpdateRulesUniquesWithNonPersistedModelInfersAttributes()
     {
         $this->trait->shouldReceive('getTable')->andReturn('users');
@@ -104,6 +119,7 @@ class UniqueValidatingStub extends \Illuminate\Database\Eloquent\Model
     use \Watson\Validating\ValidatingTrait;
 
     protected $username = 'test';
+    protected $deleted = null;
 
     public function getKey()
     {


### PR DESCRIPTION
After the functionality introduced in this PR https://github.com/dwightwatson/validating/pull/180
the semantic of the additional params of the 'NULL' string changed in a way that is not BC. This leads to produced queries that are not equivalent.

If I have a rule like `unique:users,user_id,1,id,deleted,null` what happens in `prepareUniqueRule` is that in `$parameters` the string `null` is replaced by a `NULL` value (returned by the model) and when the rule is generated by imploding `$parameters`, the `NULL` value is converted to an empty string, changing (and breaking) the semantic of the query.

The query produced by the broken rules goes from

    SELECT COUNT(*) ... WHERE deleted IS NULL
to

    SELECT COUNT(*) ... WHERE deleted = ""

This fix makes sure that NULL values returned by models are maintained as `'NULL'` (as string), so that the resulting query matches our expectation.