### PR TITLE
Remove 'rulesets' property

### DIFF
--- a/src/ValidatingModel.php
+++ b/src/ValidatingModel.php
@@ -22,13 +22,6 @@ abstract class ValidatingModel extends Eloquent implements MessageProvider, Vali
     protected $rules = [];
 
     /**
-     * The rulesets that the model will validate against.
-     *
-     * @var array
-     */
-    protected $rulesets = [];
-
-    /**
      * Get the messages for the instance.
      *
      * @return \Illuminate\Support\MessageBag


### PR DESCRIPTION
The presence of the 'rulesets' property suggests that the feature is still supported in Laravel 5.x to those who happen across it while reviewing the code.