### PR TITLE
Laravel 5.8 Compatibility

### DIFF
--- a/src/ValidatingObserver.php
+++ b/src/ValidatingObserver.php
@@ -86,6 +86,6 @@ class ValidatingObserver
      */
     protected function fireValidatedEvent(Model $model, $status)
     {
-        Event::fire("eloquent.validated: ".get_class($model), [$model, $status]);
+        Event::dispatch("eloquent.validated: ".get_class($model), [$model, $status]);
     }
 }


### PR DESCRIPTION
Using Event::dispatch instead of Event::fire (deprecated in Laravel 5.4 and removed in Laravel 5.8)