### PR TITLE
replaced studly_case() with Str::studly

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -6,6 +6,7 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Validation\Factory;
 use Illuminate\Support\Facades\Validator;
 use Watson\Validating\Injectors\UniqueInjector;
+use Illuminate\Support\Str;
 
 trait ValidatingTrait
 {
@@ -495,7 +496,7 @@ trait ValidatingTrait
      */
     protected function getUniqueIdentifierInjectorMethod($validationRule)
     {
-        $method = 'prepare' . studly_case($validationRule) . 'Rule';
+        $method = 'prepare' . Str::studly($validationRule) . 'Rule';
 
         return method_exists($this, $method) ? $method : false;
     }


### PR DESCRIPTION
After upgrading to laravel 6, i got this error for all tests that involved model validation:
Error: Call to undefined function Watson\Validating\studly_case()

I'm new to Laravel but googled a bit and was able to pass the tests with the above fix. hope it's correct.