### PR TITLE
Allow for Laravel 9 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "illuminate/contracts": "~8.0",
-        "illuminate/database": "~8.0",
-        "illuminate/events": "~8.0",
-        "illuminate/support": "~8.0",
-        "illuminate/validation": "~8.0"
+        "illuminate/contracts": "~8.0|~9.0",
+        "illuminate/database": "~8.0|~9.0",
+        "illuminate/events": "~8.0|~9.0",
+        "illuminate/support": "~8.0|~9.0",
+        "illuminate/validation": "~8.0|~9.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",


### PR DESCRIPTION
Laravel 9 is out! 
I tried fixing the tests but I don't seem to understand why they fail, I tried fixing them with no success. 
Actually, why is there no CI ? If it's wanted, I can add a Github actions script to run the tests on PR's 😄 