### PR TITLE
add custom format check to date checking

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -135,7 +135,7 @@ trait ValidatingTrait
         foreach ($attributes as $key => $value) {
             // The validator doesn't handle Carbon instances, so instead of casting
             // them we'll return their raw value instead.
-            if (in_array($key, $this->getDates()) || $this->isDateCastable($key)) {
+            if (in_array($key, $this->getDates()) || $this->isDateCastable($key) || $this->isDateCastableWithCustomFormat($key)) {
                 $attributes[$key] = $value;
                 continue;
             }

--- a/tests/ValidatingTraitTest.php
+++ b/tests/ValidatingTraitTest.php
@@ -119,7 +119,9 @@ class ValidatingTraitTest extends TestCase
             'abc'        => '123',
             'def'        => ['456'],
             'bar'        => 'rab',
-            'created_at' => '2015-01-01 00:00:00'
+            'created_at' => '2015-01-01 00:00:00', 
+            'regular_datetime' => '2015-01-01 00:00:00',
+            'custom_date' => '2015-01-01',
         ];
 
         $this->assertEquals($expected, $this->trait->getModelAttributes());
@@ -404,7 +406,9 @@ class DatabaseValidatingTraitStub extends ModelStub implements \Watson\Validatin
     ];
 
     protected $casts = [
-        'def' => 'array'
+        'def' => 'array', 
+        'regular_datettime' => 'datetime', 
+        'custom_date' => 'datetime:Y-m-d', 
     ];
 
     protected $validationMessages = [
@@ -415,16 +419,13 @@ class DatabaseValidatingTraitStub extends ModelStub implements \Watson\Validatin
         'abc'        => '123',
         'def'        => '["456"]',
         'bar'        => 'bar',
-        'created_at' => '2015-01-01 00:00:00'
+        'created_at' => '2015-01-01 00:00:00',
+        'regular_datetime' => '2015-01-01 00:00:00',
+        'custom_date' => '2015-01-01',
     ];
 
     public function getBarAttribute($value)
     {
         return strrev($value);
-    }
-
-    protected function isDateCastable($key)
-    {
-        return false;
     }
 }


### PR DESCRIPTION
Thanks so much for this package, we use it pretty extensively and are glad it exists. 

This is just a small PR to account for `custom_date` validation. 

When using a custom date cast like `date:Y-m-d` custom date validation `custom_date:Y-m-d` fails because the default returned is `Y-m-d H:i:s`. In Laravel 8 a new conern was added:  `isDateCastableWithCustomFormat()` - adding this to the `getModelAttributes()` date check resolves the issue and I haven't been able to find any side effects. 

Let me know if you have any questions and again thanks for the package. 

