### PR TITLE
Make nullable parameters with types explicit

### DIFF
--- a/src/ValidatingInterface.php
+++ b/src/ValidatingInterface.php
@@ -88,7 +88,7 @@ interface ValidatingInterface
      * @param  array $rules
      * @return void
      */
-    public function setRules(array $rules = null);
+    public function setRules(?array $rules = null);
 
     /**
      * Get the validation error messages from the model.

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -194,7 +194,7 @@ trait ValidatingTrait
      * @param  array  $attributeNames
      * @return void
      */
-    public function setValidationAttributeNames(array $attributeNames = null)
+    public function setValidationAttributeNames(?array $attributeNames = null)
     {
         $this->validationAttributeNames = $attributeNames;
     }
@@ -236,7 +236,7 @@ trait ValidatingTrait
      * @param  array $rules
      * @return void
      */
-    public function setRules(array $rules = null)
+    public function setRules(?array $rules = null)
     {
         $this->rules = $rules;
     }


### PR DESCRIPTION
These changes fix the following deprecation warnings in PHP 8.4:

```
PHP Deprecated:  Watson\Validating\ValidatingTrait::setValidationAttributeNames(): Implicitly marking parameter $attributeNames as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/watson/validating/src/ValidatingTrait.php on line 197
PHP Deprecated:  Watson\Validating\ValidatingTrait::setRules(): Implicitly marking parameter $rules as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/watson/validating/src/ValidatingTrait.php on line 239
```

The minimum PHP version according to `composer.json` is PHP 8.1, and nullable types were introduced in PHP 7.1, so this change should not cause any issues. Tests all passed on PHP 8.3 and PHP 8.4.