### PR TITLE
Fix php 8.5 deprecations

### DIFF
--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -62,7 +62,7 @@ trait ValidatingTrait
      */
     public function setValidating($value)
     {
-        $this->validating = (boolean) $value;
+        $this->validating = (bool) $value;
     }
 
     /**
@@ -86,7 +86,7 @@ trait ValidatingTrait
      */
     public function setThrowValidationExceptions($value)
     {
-        $this->throwValidationExceptions = (boolean) $value;
+        $this->throwValidationExceptions = (bool) $value;
     }
 
     /**
@@ -110,7 +110,7 @@ trait ValidatingTrait
      */
     public function setInjectUniqueIdentifier($value)
     {
-        $this->injectUniqueIdentifier = (boolean) $value;
+        $this->injectUniqueIdentifier = (bool) $value;
     }
 
     /**


### PR DESCRIPTION
Fix PHP 8.5 deprecations

Non-canonical cast names (boolean), (integer), (double), and (binary) have been deprecated, use (bool), (int), (float), and (string) respectively.

https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.non-canonical-cast-names