### PR TITLE
Adds support to Laravel 13.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "~9.0|~10.0|~11.0|~12.0",
-        "illuminate/database": "~9.0|~10.0|~11.0|~12.0",
-        "illuminate/events": "~9.0|~10.0|~11.0|~12.0",
-        "illuminate/support": "~9.0|~10.0|~11.0|~12.0",
-        "illuminate/validation": "~9.0|~10.0|~11.0|~12.0"
+        "illuminate/contracts": "~9.0|~10.0|~11.0|~12.0|~13.0",
+        "illuminate/database": "~9.0|~10.0|~11.0|~12.0|~13.0",
+        "illuminate/events": "~9.0|~10.0|~11.0|~12.0|~13.0",
+        "illuminate/support": "~9.0|~10.0|~11.0|~12.0|~13.0",
+        "illuminate/validation": "~9.0|~10.0|~11.0|~12.0|~13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4.4",

--- a/src/ValidatingTrait.php
+++ b/src/ValidatingTrait.php
@@ -40,7 +40,9 @@ trait ValidatingTrait
      */
     public static function bootValidatingTrait()
     {
-        static::observe(new ValidatingObserver);
+        static::whenBooted(function () {
+            static::observe(ValidatingObserver::class);
+        });
     }
 
     /**
@@ -54,7 +56,7 @@ trait ValidatingTrait
         return $this->validating;
     }
 
-     /**
+    /**
      * Set whether the model should attempt validation on saving.
      *
      * @param  bool $value
@@ -282,7 +284,7 @@ trait ValidatingTrait
      */
     public function isValidOrFail()
     {
-        if ( ! $this->isValid()) {
+        if (!$this->isValid()) {
             $this->throwValidationException();
         }
 
@@ -296,7 +298,7 @@ trait ValidatingTrait
      */
     public function isInvalid()
     {
-        return ! $this->isValid();
+        return !$this->isValid();
     }
 
     /**
@@ -482,18 +484,18 @@ trait ValidatingTrait
             $ruleset = is_string($ruleset) ? explode('|', $ruleset) : $ruleset;
 
             foreach ($ruleset as &$rule) {
-            	// Only treat stringy definitions and leave Rule classes and Closures as-is.
-            	if (is_string($rule)) {
-            		$parameters = explode(':', $rule);
-	                $validationRule = array_shift($parameters);
+                // Only treat stringy definitions and leave Rule classes and Closures as-is.
+                if (is_string($rule)) {
+                    $parameters = explode(':', $rule);
+                    $validationRule = array_shift($parameters);
 
-	                if ($method = $this->getUniqueIdentifierInjectorMethod($validationRule)) {
-	                    $rule = call_user_func_array(
-	                        [$this, $method],
-	                        [explode(',', head($parameters)), $field]
-	                    );
-	                }
-            	}
+                    if ($method = $this->getUniqueIdentifierInjectorMethod($validationRule)) {
+                        $rule = call_user_func_array(
+                            [$this, $method],
+                            [explode(',', head($parameters)), $field],
+                        );
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Updates dependencies in composer.json and modifies the ValidatingTrait to delay the registration of the ValidatingObserver until after the boot phase. This prevents the LogicException introduced in Laravel 13, which occurs when attempting to instantiate the current model during its boot process.