### PR TITLE
Adjust PHP version to ^8.3 to match Laravel 13.x requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "illuminate/contracts": "~13.0",
         "illuminate/database": "~13.0",
         "illuminate/events": "~13.0",


### PR DESCRIPTION
Hi! Laravel 13 [requires PHP 8.3](https://github.com/laravel/framework/blob/79d24c863438e322f45384c29421f7b0106f4560/composer.json#L21), so requiring 8.4 here does not align with Laravel requirements. This PR addresses this. I ran the tests in PHP 8.3 and all of them passed without any issues.